### PR TITLE
Use rice box to serve React app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,7 @@ sketch
 # Support for Project snippet scope
 
 # End of https://www.toptal.com/developers/gitignore/api/go,node,react,visualstudiocode
+
+ui/hashiplayero/build
+app
+rice-box.go

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/GeertJohan/go.rice v1.0.2
-	github.com/gin-gonic/contrib v0.0.0-20201101042839-6a891bf89f19
 	github.com/gin-gonic/gin v1.7.7
 )
 

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
-github.com/gin-gonic/contrib v0.0.0-20201101042839-6a891bf89f19 h1:J2LPEOcQmWaooBnBtUDV9KHFEnP5LYTZY03GiQ0oQBw=
-github.com/gin-gonic/contrib v0.0.0-20201101042839-6a891bf89f19/go.mod h1:iqneQ2Df3omzIVTkIfn7c1acsVnMGiSLn4XF5Blh3Yg=
 github.com/gin-gonic/gin v1.7.7 h1:3DoBmSbJbZAWqXJC3SLjAPfutPJJRN1U5pALB7EeTTs=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	rice "github.com/GeertJohan/go.rice"
-	"github.com/gin-gonic/contrib/static"
 	"github.com/gin-gonic/gin"
 )
 
@@ -37,7 +36,7 @@ func setRouter() *gin.Engine {
 
 	router.GET("/static/", gin.WrapH(http.FileServer(appBox.HTTPBox())))
 
-	router.Use(static.Serve("/", static.LocalFile("./../../ui/hashiplayero/build", true)))
+	router.Use(gin.WrapH(http.FileServer(appBox.HTTPBox())))
 
 	return router
 }


### PR DESCRIPTION
Previous code served app code as static files, which were being resolved in runtime.
With this change it will use data embedded in the app binary with the rice-box.go, which will result in portable binary.

I also added some rules to .gitignore to ignore app binary, rice-box.go and React build directory